### PR TITLE
fix:check body has items for php 8.1 compatibility. PSSMAS-120

### DIFF
--- a/src/Models/TableBlock.php
+++ b/src/Models/TableBlock.php
@@ -257,20 +257,23 @@ class TableBlock extends BaseElement
      */
     public function getBody()
     {
+       
         $body = $this->TableItems();
 
-        if ($this->FirstRowIsHeader == true) {
-            $body = $body->exclude([
-                'ID' => $body->First()->ID
-            ]);
-        }
+        if($body->count() > 0) {
 
-        if ($this->LastRowIsFooter == true) {
-            $body = $body->exclude([
-                'ID' => $body->Last()->ID
-            ]);
-        }
+            if ($this->FirstRowIsHeader == true) {
+                $body = $body->exclude([
+                    'ID' => $body->First()->ID
+                ]);
+            }
 
+            if ($this->LastRowIsFooter == true) {
+                $body = $body->exclude([
+                    'ID' => $body->Last()->ID
+                ]);
+            }
+        }
         return $body;
     }
 

--- a/src/Models/TableBlock.php
+++ b/src/Models/TableBlock.php
@@ -260,7 +260,7 @@ class TableBlock extends BaseElement
        
         $body = $this->TableItems();
 
-        if($body->count() > 0) {
+        if ($body->count() > 0) {
 
             if ($this->FirstRowIsHeader == true) {
                 $body = $body->exclude([


### PR DESCRIPTION
PHP 8.1 has a null error when there are no table items. 